### PR TITLE
[SCR-83] Feat/force cred as source account

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ class MacifContentScript extends ContentScript {
         try {
           // Full autoLogin is not possible on this website, there's a 2FA for each connection
           // So we're only prefilling and sending the form to reach the 2FA page.
-          await this.prefillAndSendLoginForm()
+          await this.prefillAndSendLoginForm(credentials)
           this.log('info', 'Prefill successful, waiting for 2FA ...')
         } catch {
           this.log(
@@ -230,6 +230,7 @@ class MacifContentScript extends ContentScript {
     } else {
       this.log('debug', 'Fill email field')
       await this.runInWorker('fillText', emailInputSelector, credentials.email)
+      await this.runInWorker('click', emailNextButtonSelector)
     }
 
     this.log('debug', 'Wait for password field')


### PR DESCRIPTION
This PR force de use of login credential from user's input to give as sourceAccountIdentifier.
This was needed to avoid finding folder with something different than infos found when scraping identity. The case was known thanks to Lucas, he noticed that his folder was not named after the login used but with the found email in identity. This is problematic since memberNo or email could be use to login. With that we have moved the getIdentity function and identity saving at the end of execution, so first file shows quicker to the user.

It also fix a little mistake done in the preFill method, we were not actually clicking on the wantedButton to get to password form part.